### PR TITLE
Changed harness to configure RMI objects to use port 9982 for socket connections.

### DIFF
--- a/common/src/com/sun/faban/common/CommandHandleImpl.java
+++ b/common/src/com/sun/faban/common/CommandHandleImpl.java
@@ -59,7 +59,7 @@ public class CommandHandleImpl implements CommandHandle {
     CommandHandleImpl(Command command) throws RemoteException {
         this.command = command;
         if (command.remote)
-            UnicastRemoteObject.exportObject(this);
+            UnicastRemoteObject.exportObject(this, RegistryLocator.AGENT_SERVER_PORT);
     }
 
     /**

--- a/common/src/com/sun/faban/common/RegistryLocator.java
+++ b/common/src/com/sun/faban/common/RegistryLocator.java
@@ -48,6 +48,9 @@ public class RegistryLocator {
      */
     public static final int DEFAULT_PORT = 9998;
 
+    /** The agent stub socket port. */
+    public static int AGENT_SERVER_PORT = 9982;
+    
     /**
      * The rmi registry bind name used to find the registry - FabanRegistry.
      */

--- a/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
+++ b/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
@@ -317,7 +317,7 @@ public class AgentBootstrap {
         if (agent == null) { // If not found, reregister new agent.
             boolean agentCreated = false;
             if (cmd == null) {
-                cmd = new CmdAgentImpl();
+                cmd = new CmdAgentImpl(Config.AGENT_SERVER_PORT);
                 agentCreated = true;
                 logger.fine(hostname + "(Realname: " + host +
                                                 ") created CmdAgentImpl");
@@ -341,7 +341,7 @@ public class AgentBootstrap {
 
                 // Create and reregister FileAgent
                 if (file == null)
-                    file = new FileAgentImpl();
+                    file = new FileAgentImpl(Config.AGENT_SERVER_PORT);
                 reregister(Config.FILE_AGENT + "@" + host, file);
 
                 // Register a blank Config.FILE_AGENT for the master's

--- a/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
+++ b/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
@@ -30,6 +30,7 @@ import com.sun.faban.harness.util.CmdMap;
 import com.sun.faban.harness.util.Invoker;
 
 import java.io.*;
+import java.lang.reflect.Constructor;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
@@ -102,6 +103,15 @@ public class CmdAgentImpl extends UnicastRemoteObject
     // This class must be created only through the main method.
     CmdAgentImpl() throws RemoteException {
         super();
+    }
+    
+    /**
+     * This constructor controls the port allocated to sockets. 
+     * @param port
+     * @throws RemoteException
+     */
+    CmdAgentImpl(int port) throws RemoteException {
+       super(port);
     }
 
     /**
@@ -337,7 +347,8 @@ public class CmdAgentImpl extends UnicastRemoteObject
      */
     public boolean startAgent(Class agentClass, String identifier) throws Exception {
         try {
-            Remote agent = (Remote)agentClass.newInstance();
+        	Constructor<Remote> con = agentClass.getConstructor(Integer.class);
+            Remote agent = con.newInstance(Config.AGENT_SERVER_PORT);
             logger.fine("Agent class " + agent.getClass().getName() + " created");
             AgentBootstrap.registry.reregister(identifier, agent);
             logger.fine("Agent started and Registered as " + identifier);

--- a/harness/src/com/sun/faban/harness/agent/FileAgentImpl.java
+++ b/harness/src/com/sun/faban/harness/agent/FileAgentImpl.java
@@ -58,6 +58,16 @@ public class FileAgentImpl extends UnicastRemoteObject
         logger = Logger.getLogger(this.getClass().getName());
     }
 
+   /**
+   * Constructs the file agent.
+   * @param int - The port number allocated to the socket.
+   * @throws RemoteException A communications error occurred.
+   */
+   public FileAgentImpl(int port) throws RemoteException {
+       super(port);
+       logger = Logger.getLogger(this.getClass().getName());
+   }
+
     /**
      *
      * This method creates a new FileServiceImpl object and returns a 
@@ -321,7 +331,7 @@ public class FileAgentImpl extends UnicastRemoteObject
     // Registration for RMI serving - used only for stand-alone testing.
 
     /**
-     * Starts a standalong file agent.
+     * Starts a standalone file agent.
      * @param argv Command line arguments, not used
      */
     public static void main(String [] argv) {
@@ -330,7 +340,7 @@ public class FileAgentImpl extends UnicastRemoteObject
         System.setSecurityManager (new RMISecurityManager());
 
         try {
-            FileAgentImpl log = new FileAgentImpl();
+            FileAgentImpl log = new FileAgentImpl(Config.AGENT_SERVER_PORT);
             System.out.println("FileAgentImpl object created");
             String host = (InetAddress.getLocalHost()).getHostName();
             String s = "//" + host  + "/FileAgent";

--- a/harness/src/com/sun/faban/harness/common/Config.java
+++ b/harness/src/com/sun/faban/harness/common/Config.java
@@ -126,6 +126,9 @@ public class Config {
     /** The agent daemon port. */
     public static int AGENT_PORT = 9981;
 
+    /** The agent stub socket port. */
+   public static int AGENT_SERVER_PORT = 9982;
+
     /** resultinfo contains a single line summary result. */
     public static final String RESULT_INFO = "resultinfo";
 

--- a/harness/src/com/sun/faban/harness/services/ServiceManager.java
+++ b/harness/src/com/sun/faban/harness/services/ServiceManager.java
@@ -312,7 +312,6 @@ public class ServiceManager {
                 String serviceName = par.getParameter("fh:name",
                                                         serviceElement);
 
-                //boolean enabled = par.getBooleanValue("fh:enabled", true);
                 boolean enabled = par.getBooleanValue("fh:enabled", serviceElement);
                 if (!enabled)
                     continue;


### PR DESCRIPTION
I am having problems starting Faban. In my setup there are two machines A and B. The master runs on A and an an agent on B. As normal there is an RMI registry running on A when Faban starts the run.
When the system starts a CmdAgent object is created on B and registered on A. The Stub reference to the object has a TCPEndpoint and this endpoint has allocated an anonymous port number.

Allocating an anonymous port number is an issue for me because having the firewall with a wide range of ports opened is not an option. The anonymous port behaviour is used when 0 is passed to RMISocketFactory.createServerSocket(int). With anonymous port allocation I get java.net.NoRouteToHostException when Stub reference methods are called. See this article for similar details.
http://scis.athabascau.ca/html/courses/comp489/mysql/rmi-firewall.htm

These classes are updated to take a defined port number on construction:

com.sun.faban.harness.agent.CmdAgentImpl
com.sun.faban.harness.agent.FileAgentImpl
com.sun.faban.common.CommandHandleImpl

And change the Agent daemon to allocate the port number.

com.sun.faban.harness.agent.AgentBootstrap.startDaemon()

The opened port is configured on the firewall for both A and B.

Looking at the FAQs the first unallocated port number is 9982. This change has been tested with 1 and multi-tier SUT allowing the RMI Stub references to access remote objects.

In addition to a code change the FAQ needs updating too.

Regards,
Jeremy
