### PR TITLE
De-warning-ifying faban builds

### DIFF
--- a/common/build.xml
+++ b/common/build.xml
@@ -57,7 +57,9 @@
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
             target="${compiler.target.version}"
-            memoryMaximumSize="${compiler.max.memory}" fork="true">
+            memoryMaximumSize="${compiler.max.memory}"
+            includeAntRuntime="false"
+            fork="true">
             <compilerarg line="${compiler.args}"/>
             <src refid="source.path"/>
         </javac>

--- a/driver/build.xml
+++ b/driver/build.xml
@@ -70,7 +70,9 @@
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
             target="${compiler.target.version}"
-            memoryMaximumSize="${compiler.max.memory}" fork="true">
+            memoryMaximumSize="${compiler.max.memory}"
+            includeAntRuntime="false"
+            fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="class.path"/>
             <src refid="source.path"/>

--- a/harness/build.xml
+++ b/harness/build.xml
@@ -74,7 +74,9 @@
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
             target="${compiler.target.version}"            
-            memoryMaximumSize="${compiler.max.memory}" fork="true">
+            memoryMaximumSize="${compiler.max.memory}"
+            includeAntRuntime="false"
+            fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="class.path"/>
             <src refid="source.path"/>


### PR DESCRIPTION
Ant would generate warnings when running without this attribute.
It may be related to use of ant 1.7.
