### PR TITLE
Fix for Issue #22

### DIFF
--- a/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
+++ b/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
@@ -304,10 +304,15 @@ public class AgentBootstrap {
         // The host name is widely used in result files, tools, etc. We
         // do not want that baggage. So we make sure to crop it off.
         // i.e. brazilian.sfbay.Sun.COM should just show as brazilian.
-        int dotIdx = host.indexOf('.');
-        if (dotIdx > 0)
-            host = host.substring(0, dotIdx);
 
+        // Keep just the one dot after the host. In example above, brazilian.sfbay
+        logger.finer("Original host is " + host);
+        int dotIdx = host.indexOf(".");
+        int nextDotIdx = host.substring(dotIdx+1).indexOf('.');
+        if (nextDotIdx > 0)
+            host = host.substring(0, dotIdx + nextDotIdx + 1);
+        logger.finer("dotIdx is " + dotIdx + ", nextDotIdx is " + nextDotIdx +
+                ", Modified Host is " + host);
         //ident will be unique
         ident = Config.CMD_AGENT + "@" + host;
 

--- a/harness/src/com/sun/faban/harness/engine/ServerConfig.java
+++ b/harness/src/com/sun/faban/harness/engine/ServerConfig.java
@@ -302,7 +302,8 @@ class ServerConfig {
 
         for (ParamRepository.HostConfig hostConfig : hostConfigs) {
             for(String host : hostConfig.hosts) {
-                File f = new File(sysfile + "." + host);
+                String machineName = cmds.getHostName(host);
+                File f = new File(sysfile + "." + machineName);
                 f.delete();
                 try {
                     syslog = new PrintStream(new FileOutputStream(f));


### PR DESCRIPTION
Instead of stripping out everything at and after the first '.' in the hostname, keep the part after the first dot only. This ensures that hostnames with one dot will work (e.g. all default Mac hostnames).
