### PR TITLE
Stats navigator does not show correct hostname

### DIFF
--- a/harness/web/statsnavigator.jsp
+++ b/harness/web/statsnavigator.jsp
@@ -78,16 +78,7 @@
         // Then proces the sysinfo files...
         if (fileName.startsWith("sysinfo.")) {
             String hostName = fileName.substring(8, fileName.length() - 5);
-
-            // drop the domain part of the host.
-            int domainIdx = hostName.indexOf('.');
-            if (domainIdx != -1) {
-                String fullName = hostName;
-                hostName = fullName.substring(0, domainIdx);
-                infoHostMap.put(hostName, fullName);
-            } else {
-                infoHostMap.put(hostName, hostName); // Points to it's own name
-            }
+            infoHostMap.put(hostName, hostName); // Points to it's own name
             allHosts.add(hostName);
 
         // Process the real stats files.


### PR DESCRIPTION
The fix for Issue #22 did not fix statsnavigator.jsp. It still strips out the domain name part when evaluating the sysinfo file, leading to a wrong name being displayed.
