### PR TITLE
rootinstall.sh does not work on Linux

### DIFF
--- a/harness/bin/rootinstall.sh
+++ b/harness/bin/rootinstall.sh
@@ -6,9 +6,9 @@ if [ -x "/usr/xpg4/bin/id" ] ; then
     IDCMD=/usr/xpg4/bin/id
 fi
 
-UID=`$IDCMD -u`
+uid=`$IDCMD -u`
 
-if [ $UID != 0 ] ; then
+if [ $uid != 0 ] ; then
     echo "$0: Needs to be run as superuser" >&2
     exit 1
 fi
@@ -16,7 +16,7 @@ fi
 BINDIR=`dirname $0`
 cd $BINDIR
 
-FILELIST="SunOS/x86/fastsu SunOS/sparc/fastsu Linux/i386/nicstat"
+FILELIST="SunOS/x86/fastsu SunOS/sparc/fastsu Linux/*/nicstat*"
 
 for i in $FILELIST
 do


### PR DESCRIPTION
There are multiple problems:
a) UID cannot be used as it is predefined in sh.
b) nicstat is no longer a binary. Need to use nicstat*
c) We now have multiple Linux architectures, not just i386. Need to consider them all for nicstat.
