### PR TITLE
Add a message in the log when a user command is being executed

### DIFF
--- a/harness/resources/config-template.xhtml
+++ b/harness/resources/config-template.xhtml
@@ -52,7 +52,7 @@
                 <xforms:label xforms:model="benchmark-labels" xforms:ref="/labels/cancel"/>
                 <xforms:action id="action-cancel">
                     <xforms:reset id="reset-cancel" xforms:model="benchmark-model"/>
-                    <xforms:toggle id="toggle-cancel" xforms:case="case-jvmConfig"/>
+                    <xforms:toggle id="toggle-cancel" xforms:case="case-runConfig"/>
                 </xforms:action>
             </xforms:trigger>
         </xforms:group>

--- a/harness/src/com/sun/faban/harness/engine/ServerConfig.java
+++ b/harness/src/com/sun/faban/harness/engine/ServerConfig.java
@@ -117,6 +117,7 @@ class ServerConfig {
                         for (String cmdString : cmdStrings) {
                             Command c = new Command(cmdString);
                             c.setStreamHandling(Command.STDOUT,Command.CAPTURE);
+                            logger.info("Executing '" + cmdString + "'");
                             handle = cmds.execute(host, c, null);
                             info = handle.fetchOutput(Command.STDOUT);
                             if (info != null) {

--- a/harness/src/com/sun/faban/harness/util/FileHelper.java
+++ b/harness/src/com/sun/faban/harness/util/FileHelper.java
@@ -161,8 +161,8 @@ public class FileHelper {
         if(!FileHelper.copyFile(fileName, backupFileName, false))
             return false; // Failed to backup the file
 
-        logger.fine("Token : " + token);
-        logger.fine("Replacement : " + replacement);
+        logger.finest("Token : " + token);
+        logger.finest("Replacement : " + replacement);
 
         try {
             BufferedReader in = new BufferedReader(new FileReader(backupFileName));


### PR DESCRIPTION
Sometimes a user specified command in the run form can take a long time to run and the user is left to wonder what is going on.

Add a logger.info line to indicate when executing UserCommands before a run.
