### PR TITLE
Fix for Issue: "After a delete run, tag search throws exception"

### DIFF
--- a/harness/src/com/sun/faban/harness/webclient/ResultAction.java
+++ b/harness/src/com/sun/faban/harness/webclient/ResultAction.java
@@ -461,12 +461,21 @@ public class ResultAction {
     }
 
     public String deleteResults(HttpServletRequest request,
-                        HttpServletResponse response) {
+                        HttpServletResponse response) throws IOException {
         String[] runIds = request.getParameterValues("select");
         if (runIds != null) {
+            TagEngine tagEngine;
+            try {
+                tagEngine = TagEngine.getInstance();
+            } catch (ClassNotFoundException ex) {
+                logger.log(Level.SEVERE, "Cannot find tag engine class", ex);
+                throw new IOException("Cannot find tag engine class", ex);
+            }
             for (String r : runIds) {
                 RunResult runResult = RunResult.getInstance(new RunId(r));
                 runResult.delete(r);
+                tagEngine.removeRun(r);
+                tagEngine.save();
             }
         }
         HttpSession session = request.getSession();

--- a/harness/src/com/sun/faban/harness/webclient/RunResult.java
+++ b/harness/src/com/sun/faban/harness/webclient/RunResult.java
@@ -403,8 +403,8 @@ public class RunResult {
                     } catch (Exception e) {
                         logger.log(Level.WARNING, "Cannot remove run " + runid, e);
                     }
-                }
-                resultList.add(res);
+                } else
+                    resultList.add(res);
             } catch (Exception e) {
                 logger.log(Level.WARNING, "Cannot read result dir " + runid, e);
             }


### PR DESCRIPTION
There were two bugs fixed:
a) The tag was not getting deleted on a delete run
b) The result list was adding run ids that were null (i.e. already deleted)
