### PR TITLE
Fix Issue 38: 'ClassNotFoundException...' search agent ${ServiceName}/li...

### DIFF
--- a/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
+++ b/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
@@ -176,7 +176,7 @@ public class CmdAgentImpl extends UnicastRemoteObject
             }
 
             ArrayList<String> libList = new ArrayList<String>();
-            getClassPath(Config.SERVICE_DIR + path, libList);
+            getClassPath(Config.SERVICE_DIR + path + "/lib/", libList);
             if (libList.size() > 0) {
                 if (servicesClassPath.get(path) == null) {
                     servicesClassPath.put(path, libList);


### PR DESCRIPTION
...b for jars

Agent with different FABAN_HOME than master would not find serice jars because it scanned ${ServiceName} and not ${ServiceName}/lib. Agent now scans ${ServiceName}/lib/
