### PR TITLE
TimedInputStream can sleep "forever" if throttling is used

### DIFF
--- a/driver/src/com/sun/faban/driver/transport/util/TimedInputStream.java
+++ b/driver/src/com/sun/faban/driver/transport/util/TimedInputStream.java
@@ -165,8 +165,9 @@ public class TimedInputStream extends FilterInputStream {
         boolean isThrottled = false;
         if (ctx != null) {
             isThrottled = throttle.isThrottled(Throttle.DOWN);
-            if (isThrottled)
-                startReadAt = ctx.getNanoTime();
+            if (isThrottled) {
+                startReadAt = System.nanoTime();
+            }
         }
         int bytes = super.read(b, off, len);
         if (ctx != null && bytes > 0) {


### PR DESCRIPTION
When throttling input stream set start time to current nanotime.
This fixed the hang (extremely long sleep, really) noted in issue #31.
