### PR TITLE
Fix issue with Detailed Results breaking link target

### DIFF
--- a/harness/web/xan_view.jsp
+++ b/harness/web/xan_view.jsp
@@ -183,6 +183,10 @@ $(function () {
                 show: true
             }
         });
+        //Hack to prevent jqplot from changing frame name in Chrome
+        if(window.name="y9axis"){
+            window.name="display";
+        }
     <% } %>
 });
 </script>


### PR DESCRIPTION
jqplot changes window name to y9axis which breaks links in resultnavigator.jsp that target display.
This provides a workaround by changing the window.name to display after each chart is created
A long term solution needs to come from jqplot.
