### PR TITLE
Allow using JDK 1.7 to compile faban.

### DIFF
--- a/common/build-defaults.properties
+++ b/common/build-defaults.properties
@@ -2,5 +2,5 @@ compiler.debug=on
 compiler.generate.no.warnings=off
 compiler.args=-Xlint
 compiler.max.memory=128m
-compiler.target.version=1.5
+compiler.source.version=1.5
 junit.jar=/opt/netbeans-6.5/platform9/modules/ext/junit-4.5.jar

--- a/common/build.xml
+++ b/common/build.xml
@@ -57,7 +57,7 @@
         <mkdir dir="${compile.output}"/>
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false"
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <src refid="source.path"/>
@@ -69,7 +69,7 @@
         <mkdir dir="${compile.test.output}"/>
         <javac destdir="${compile.test.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false"
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="test.class.path"/>
@@ -143,7 +143,7 @@
     <target name="rmic" depends="compile"
         description="Create rmi stubs and skeletons">
         <rmic base="${compile.output}"
-            stubversion="${compiler.target.version}"
+            stubversion="1.2"
             includes="**/*Impl.class"
             excludes="**/*$*.class"/>
     </target>

--- a/driver/build-defaults.properties
+++ b/driver/build-defaults.properties
@@ -2,5 +2,5 @@ compiler.debug=on
 compiler.generate.no.warnings=off
 compiler.args=
 compiler.max.memory=128m
-compiler.target.version=1.5
+compiler.source.version=1.5
 junit.jar=/opt/netbeans-6.5/platform9/modules/ext/junit-4.5.jar

--- a/driver/build.xml
+++ b/driver/build.xml
@@ -72,7 +72,7 @@
         <mkdir dir="${compile.output}"/>
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false"
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="class.path"/>
@@ -86,7 +86,7 @@
         <mkdir dir="${compile.test.output}"/>
         <javac destdir="${compile.test.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false"
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="test.class.path"/>
@@ -162,7 +162,7 @@
     <target name="rmic" depends="compile"
         description="Create rmi stubs and skeletons">
         <rmic base="${compile.output}"
-              stubversion="${compiler.target.version}"
+              stubversion="1.2"
               includes="**/engine/*Impl.class"/>
     </target>
 

--- a/harness/build-defaults.properties
+++ b/harness/build-defaults.properties
@@ -2,5 +2,5 @@ compiler.debug=on
 compiler.generate.no.warnings=off
 compiler.args=
 compiler.max.memory=128m
-compiler.target.version=1.5
+compiler.source.version=1.5
 junit.jar=/opt/netbeans-6.5/platform9/modules/ext/junit-4.5.jar

--- a/harness/build.xml
+++ b/harness/build.xml
@@ -76,7 +76,7 @@
         <mkdir dir="${compile.output}"/>
         <javac destdir="${compile.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false" 
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="class.path"/>
@@ -89,7 +89,7 @@
         <mkdir dir="${compile.test.output}"/>
         <javac destdir="${compile.test.output}" debug="${compiler.debug}"
             nowarn="${compiler.generate.no.warnings}"
-            target="${compiler.target.version}" includeantruntime="false"
+            source="${compiler.source.version}" includeantruntime="false"
             memoryMaximumSize="${compiler.max.memory}" fork="true">
             <compilerarg line="${compiler.args}"/>
             <classpath refid="test.class.path"/>
@@ -167,7 +167,7 @@
     <target name="rmic" depends="compile"
         description="Create rmi stubs and skeletons">
         <rmic base="${compile.output}"
-            stubversion="${compiler.target.version}"
+            stubversion="1.2"
             includes="**/*Impl.class"
             excludes="**/*$*.class">
             <classpath refid="class.path"/>

--- a/samples/benchmarks/fabanload/build.properties
+++ b/samples/benchmarks/fabanload/build.properties
@@ -4,4 +4,4 @@ faban.url=http://brazilian:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=false
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/benchmarks/fabanload/build.xml
+++ b/samples/benchmarks/fabanload/build.xml
@@ -31,7 +31,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" target="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/benchmarks/ftp101/build.properties
+++ b/samples/benchmarks/ftp101/build.properties
@@ -4,4 +4,4 @@ faban.url=http://brazilian.sfbay:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=false
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/benchmarks/ftp101/build.xml
+++ b/samples/benchmarks/ftp101/build.xml
@@ -31,7 +31,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" target="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/benchmarks/hadoopgridmix/build.properties
+++ b/samples/benchmarks/hadoopgridmix/build.properties
@@ -4,4 +4,4 @@ faban.url=http://brazilian:9980
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/benchmarks/hadoopgridmix/build.xml
+++ b/samples/benchmarks/hadoopgridmix/build.xml
@@ -195,7 +195,7 @@
 
     <target name="compile" depends="init,GridMix" description="Compiling all source files">
         <javac srcdir="${src.dir}"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" target="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="com/sun/hadoop/harness/GridMix.java" />
             <classpath refid="classpath"/>

--- a/samples/benchmarks/specweb2005/build.properties
+++ b/samples/benchmarks/specweb2005/build.properties
@@ -4,4 +4,4 @@ faban.url=http://brazilian.sfbay:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=false
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/benchmarks/specweb2005/build.xml
+++ b/samples/benchmarks/specweb2005/build.xml
@@ -31,7 +31,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" target="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/benchmarks/web101/build.properties
+++ b/samples/benchmarks/web101/build.properties
@@ -4,4 +4,4 @@ faban.url=http://brazilian:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/benchmarks/web101/build.xml
+++ b/samples/benchmarks/web101/build.xml
@@ -31,7 +31,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/ApacheHttpdService/build.properties
+++ b/samples/services/ApacheHttpdService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/ApacheHttpdService/build.xml
+++ b/samples/services/ApacheHttpdService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/GlassfishService/build.properties
+++ b/samples/services/GlassfishService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/GlassfishService/build.xml
+++ b/samples/services/GlassfishService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/LighttpdService/build.properties
+++ b/samples/services/LighttpdService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/LighttpdService/build.xml
+++ b/samples/services/LighttpdService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/MemcachedService/build.properties
+++ b/samples/services/MemcachedService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/MemcachedService/build.xml
+++ b/samples/services/MemcachedService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/MysqlService/build.properties
+++ b/samples/services/MysqlService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/MysqlService/build.xml
+++ b/samples/services/MysqlService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>

--- a/samples/services/OracleService/build.properties
+++ b/samples/services/OracleService/build.properties
@@ -4,4 +4,4 @@ faban.url=http://localhost:9980/
 deploy.user=deployer
 deploy.password=adminadmin
 deploy.clearconfig=true
-compiler.target.version=1.5
+compiler.source.version=1.5

--- a/samples/services/OracleService/build.xml
+++ b/samples/services/OracleService/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile" depends="init" description="Compiling all source files">
         <javac srcdir="${src.dir}" includeantruntime="false"
-            deprecation="on" target="${compiler.target.version}"
+            deprecation="on" source="${compiler.source.version}"
             destdir="${classes.dir}" debug="on">
             <include name="**/*.java" />
             <classpath refid="classpath"/>


### PR DESCRIPTION
In 1.7, specifying only the target version as was done in faban
build.xml is an error. If we specify source version instead, it
implies target and compilation succeeds. Doing it this way works with
JDK 1.6 as well (tested these changes with 1.6.0_21 and 1.7.0_25).

(Not sure if we really need to be compiling this to 1.5 anymore, but
I've left that unchanged for now. Can be upgraded later if desired.)

Also, build.xml was passing the same version to rmic 'stubversion'
which is incorrect (though it only generates a warning). The only
valid values for stubversion are 1.1 and 1.2, it doesn't take the full
range of JDK versions. Changed this to "1.2" which is the default.
