### PR TITLE
Fix handling of hosts for the common case where the hostname has no dots.

### DIFF
--- a/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
+++ b/harness/src/com/sun/faban/harness/agent/AgentBootstrap.java
@@ -314,7 +314,10 @@ public class AgentBootstrap {
         logger.finer("dotIdx is " + dotIdx + ", nextDotIdx is " + nextDotIdx +
                 ", Modified Host is " + host);
 
-        String shortHost = host.substring(0, dotIdx);   // eliminate all dots
+        String shortHost = host;
+        if (dotIdx > 0) {
+          shortHost = host.substring(0, dotIdx);   // eliminate all dots
+        }
 
         // Check which host is the valid name
         host = checkHost(host, shortHost);


### PR DESCRIPTION
This broke recently with changes to issue-22.

When the initial hostname has no dots, dotIdx is -1. The
host.substring call then throws an exception and registration of this
host is bypassed.

While this section of code could be cleaned up further, a simple fix
here is to only attempt the substring if dotIdx is actually positive
(that is, if the host had some dots).
