### PR TITLE
Fix null pointer exception when deleting a run from the web UI.

### DIFF
--- a/harness/src/com/sun/faban/harness/webclient/TagEngine.java
+++ b/harness/src/com/sun/faban/harness/webclient/TagEngine.java
@@ -267,8 +267,10 @@ public class TagEngine implements Serializable{
         wlock.lock();
         try {
             HashSet<Entry> removeSet = runEntries.get(runId);
-            for (Entry entry : removeSet) {
-                entry.runIds.remove(runId);
+            if (removeSet != null) {
+                for (Entry entry : removeSet) {
+                    entry.runIds.remove(runId);
+                }
             }
             runEntries.remove(runId);
         } finally {


### PR DESCRIPTION
Previously, when selecting a run and clicking 'Delete' (from the View
Results page) resulted in an exception being shown in the page
(although the run data did get deleted from disk). If multiple runs
had been selected, only the first one was actually deleted from disk.
