### PR TITLE
fix issue where service jars were dropped from RMI classPath

### DIFF
--- a/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
+++ b/harness/src/com/sun/faban/harness/agent/CmdAgentImpl.java
@@ -175,14 +175,16 @@ public class CmdAgentImpl extends UnicastRemoteObject
                 logger.log(Level.INFO, ex.getMessage() , ex);
             }
 
-            ArrayList<String> libList = new ArrayList<String>();
-            getClassPath(Config.SERVICE_DIR + path + "/lib/", libList);
-            if (libList.size() > 0) {
-                if (servicesClassPath.get(path) == null) {
-                    servicesClassPath.put(path, libList);
-                    allClassPathList.addAll(libList);
-                }
+            List<String> libList = servicesClassPath.get(path);
+            //servicesClassPath will return null if the service has not been seen before
+            if (libList==null){
+            	libList = new ArrayList<String>();
+            	getClassPath(Config.SERVICE_DIR + path + "/lib/", libList);
+            	servicesClassPath.put(path, libList);
             }
+
+            allClassPathList.addAll(libList);
+            
         }
         for (String classPath : baseClassPath)
             allClassPathList.add(classPath);
@@ -611,7 +613,7 @@ public class CmdAgentImpl extends UnicastRemoteObject
     }
 
     private static void getClassPath(String libDirPath,
-                                     ArrayList<String> libList) {
+                                     List<String> libList) {
         File libDir = new File(libDirPath);
         if (libDir.isDirectory()) {
             File[] libFiles = libDir.listFiles();


### PR DESCRIPTION
CmdAgentImpl uses a cache of service jars. The previous logic would only
add the service jars to allClassPath if they were not in the cache but
the same method replaces the content of allClassPath at the end so it
effectly removed the service jars from the classPath after the second
invocation. This change uses the same cache but includes the service
jars after each invocation.
