### PR TITLE
Moved some quotation marks to fix an issue with starting / stopping the harness on Windows.

### DIFF
--- a/stage/master/bin/shutdown-using-launcher.bat
+++ b/stage/master/bin/shutdown-using-launcher.bat
@@ -35,6 +35,6 @@ goto setArgs
 :doneSetArgs
 
 rem Execute the Launcher using the "catalina" target
-"%JAVA_HOME%\bin\java.exe" -classpath %PRG%\..;"%PATH%";. LauncherBootstrap -launchfile catalina.xml -verbose catalina %CMD_LINE_ARGS% stop
+"%JAVA_HOME%\bin\java.exe" -classpath "%PRG%\..;%PATH%;." LauncherBootstrap -launchfile catalina.xml -verbose catalina %CMD_LINE_ARGS% stop
 
 :end

--- a/stage/master/bin/startup-using-launcher.bat
+++ b/stage/master/bin/startup-using-launcher.bat
@@ -34,6 +34,6 @@ goto setArgs
 :doneSetArgs
 
 rem Execute the Launcher using the "catalina" target
-"%JAVA_HOME%\bin\java.exe" -classpath %PRG%\..;"%PATH%";. LauncherBootstrap -launchfile catalina.xml -verbose catalina %CMD_LINE_ARGS% start
+"%JAVA_HOME%\bin\java.exe" -classpath "%PRG%\..;%PATH%;." LauncherBootstrap -launchfile catalina.xml -verbose catalina %CMD_LINE_ARGS% start
 
 :end


### PR DESCRIPTION
Before these changes, running the startup-using-launcher.bat or shutdown-using-launcher.bat scripts would result in a java usage error.

I have tested these changes on Windows 7, with java 1.7.0_80, and they seem to work fine.
I am not sure if these changes will have a negative impact on older versions of Windows, but it doesn't seem like they should.

