### PR TITLE
[Fix]: `RunQ.listRunQ` returns `null` data

### DIFF
--- a/harness/src/com/sun/faban/harness/engine/RunQ.java
+++ b/harness/src/com/sun/faban/harness/engine/RunQ.java
@@ -241,7 +241,9 @@ public class RunQ {
      *
      */
     public String[][] listRunQ() {
-        String[][] data = null;
+        //this causes unexpected nullpointer exception later
+    	//String[][] data = null;
+    	String [][] data = new String[0][0];
 
         try {
             File runqDirPath = new File(Config.RUNQ_DIR);


### PR DESCRIPTION
`RunQ.listRunQ` returned a `null` object reference in some cases.
We changed it to return an empty , 0 sized String array insted.
This doesn’t break existing logic, but prevents a possible
`NullPointerException`.

Example: submitting a run with a non existent benchmark name caused a
`NullPointerException` on the `CLIServlet` side. Now it behaves as
expected, returning HTTP status code NOT FOUND.