### PR TITLE
 Fixed issue where 'file:/' was prefixed. Which caused TransformerExc…

### DIFF
--- a/harness/src/com/sun/faban/harness/util/XMLReader.java
+++ b/harness/src/com/sun/faban/harness/util/XMLReader.java
@@ -526,7 +526,7 @@ public class XMLReader {
         }
 
         DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(new File(file));
+        StreamResult result = new StreamResult(new File(file).getAbsolutePath());
         transformer.transform(source, result);
 
         return true;


### PR DESCRIPTION
…eption. absolutePath omits protocol.

This solves an issue when using jdk9.