### PR TITLE
Force wait on all Agents to complete initialization.

### DIFF
--- a/driver/src/com/sun/faban/driver/engine/MasterImpl.java
+++ b/driver/src/com/sun/faban/driver/engine/MasterImpl.java
@@ -648,11 +648,8 @@ public class MasterImpl extends UnicastRemoteObject implements Master {
      */
     private void executeRun() throws Exception {
 
-        // Now wait for all threads to start if it is parallel.
-        if (runInfo.parallelAgentThreadStart) {
-			waitForThreadStart();
-		}
-        
+		waitForThreadStart();
+
         // Start thread to dump stats for charting
         if (runInfo.runtimeStatsEnabled)
             statsWriter = new StatsWriter();


### PR DESCRIPTION
This change will ensure the benchmark does not start benchmark operations before all driver classes have been started/constructed.
This is to solve #94 .