### PR TITLE
fix: Suppress Smap debug information.

### DIFF
--- a/stage/master/conf/web.xml
+++ b/stage/master/conf/web.xml
@@ -194,6 +194,10 @@
             <param-name>xpoweredBy</param-name>
             <param-value>false</param-value>
         </init-param>
+        <init-param>
+            <param-name>suppressSmap</param-name>
+            <param-value>true</param-value>
+        </init-param>
         <load-on-startup>3</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
 By default JSP when compiled will include debug information for languages. The compilation is done by the Jasper project.

 When using Faban with JDK9 the Jasper compiler does not recognize a particular byte-code generated. Not present before JDK9. This causes an [IOException](https://github.com/akara/faban/issues/92#issuecomment-362233992) to be thrown. 

 By disabling the addition of Smap debug info the exception no longer happens. Which means the JSP are compiled and the web pages are rendered as normal.

 This fixes the issue mentioned in [#92](https://github.com/akara/faban/issues/92#issuecomment-362233992).