### PR TITLE
fix: Added Xerces and Xalan to the Faban web app.

### DIFF
--- a/harness/build.xml
+++ b/harness/build.xml
@@ -200,7 +200,7 @@
 	    <fileset dir="${web.dir}"/>
 	    <!-- Note: Dom and Xalan libs need to go into "endorsed" to run
 	    the Faban Harness in JDK 1.5, it conflicts with 1.5 libs. -->
-	    <lib     dir="${lib.dir}" excludes="dom3-*, xalan.jar"/>
+	    <lib     dir="${lib.dir}"/>
 	    <lib     dir="${jar.output}" includes="${jar.file}"/>
 	    <webinf  dir="${deploy.dir}" includes="chiba-config.xml"/>
 	    <classes dir="${compile.output}"

--- a/harness/deploy/web.xml
+++ b/harness/deploy/web.xml
@@ -41,6 +41,22 @@
             <param-name>xsltDir</param-name>
             <param-value>xslt</param-value>
         </init-param>
+        <init-param>
+            <param-name>internalXercesImpl</param-name>
+            <param-value>com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl</param-value>
+        </init-param>
+        <init-param>
+            <param-name>xercesImpl</param-name>
+            <param-value>org.apache.xerces.jaxp.DocumentBuilderFactoryImpl</param-value>
+        </init-param>
+        <init-param>
+            <param-name>internalXalanImpl</param-name>
+            <param-value>com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl</param-value>
+        </init-param>
+        <init-param>
+            <param-name>xalanImpl</param-name>
+            <param-value>org.apache.xalan.processor.TransformerFactoryImpl</param-value>
+        </init-param>
     </servlet>
     <servlet>
         <servlet-name>Dispatcher</servlet-name>


### PR DESCRIPTION
Switch the XML document factory and XSLT transformer when necessary for Chiba.

 Switching the default implementation to the bundled XML and XSLT enable Chiba integration to continue working. 

 Chiba is coded in places to use the Xerces and Xalan library classes. Without endorsed libraries being loaded initially the JDK internal equivalent is used for parsing and transforming. Which then causes ClassCastException exceptions when Chiba attempts to cast a JDK internal class to a non-internal class. 