### PR TITLE
XML libary switching for Chiba.

### DIFF
--- a/harness/src/com/sun/faban/harness/webclient/XFormServlet.java
+++ b/harness/src/com/sun/faban/harness/webclient/XFormServlet.java
@@ -227,6 +227,8 @@ public class XFormServlet extends HttpServlet {
                     logger.finer("added request param '" + s + "' to beanCtx");
                 }
             }
+            System.setProperty(XML_PARSER_FACTORY, xercesImpl);
+            System.setProperty(XSLT_TRANSFORMER_FACTORY, xalanImpl);
             adapter.init();
             adapter.execute();
 
@@ -240,7 +242,8 @@ public class XFormServlet extends HttpServlet {
             logger.log(Level.SEVERE, "Exception processing XForms", e);
             shutdown(adapter, session, e, request, response);
         } finally {
-           System.setProperty(XML_PARSER_FACTORY, internalXercesImpl);
+            System.setProperty(XML_PARSER_FACTORY, internalXercesImpl);
+            System.setProperty(XSLT_TRANSFORMER_FACTORY, internalXalanImpl);
         }
     }
 
@@ -269,7 +272,7 @@ public class XFormServlet extends HttpServlet {
                                  "User-Agent"));
             adapter.beanCtx.put("chiba.web.request", request);
             adapter.beanCtx.put("chiba.web.session", session);
-            //adapter.executeHandler();
+            System.setProperty(XML_PARSER_FACTORY, xercesImpl);
             adapter.execute();
 
             // Check for redirects


### PR DESCRIPTION
 The need to switch the XML implementation from the default JDK to a bundled Xerces has been found to be necessary in more places.

 Wherever Chiba Adapter is used Xerces must be also used.

 Without this the Web UI is unresponsive. See issue #99 for more details of the problems being fixed by this PR.