### PR TITLE
Correct shell non-compatability issues.

### DIFF
--- a/stage/master/bin/catalina.sh
+++ b/stage/master/bin/catalina.sh
@@ -127,7 +127,7 @@ fi
 #echo "MINORVER:$MINORVER"
 
 # add java.endorsed.dirs for pre JRE 9 image
-if  (("$MAJORVER" > 8))  || [ -z "$MAJORVER" ]; then
+if  [ "$MAJORVER" > 8 ]  || [ -z "$MAJORVER" ]; then
     ENDORSED_OPTS=""
 else
     ENDORSED_OPTS=" -Djava.endorsed.dirs=$JAVA_ENDORSED_DIRS "

--- a/stage/master/bin/startup.sh
+++ b/stage/master/bin/startup.sh
@@ -22,7 +22,7 @@ JAVA_VER_STRING=`${JAVA_HOME}/bin/java -version 2>&1`
 
 JAVA_VERSION=`echo $JAVA_VER_STRING | \
                awk '{ print substr($3, 2, length($3) - 2)}'`
-if [[ "$JAVA_VERSION" =~ "\." ]] ; then
+if [ "$JAVA_VERSION" = "\." ] ; then
    MAJORVER=$JAVA_VERSION
    MINORVER="0"
 else


### PR DESCRIPTION
 Control scripts now work again across variety of shells. Converted equality operator to correct type for strings.

This PR aims to solve issue #115 
